### PR TITLE
feat: ethereum load test by timer

### DIFF
--- a/chains/ethereum/runner/runner.go
+++ b/chains/ethereum/runner/runner.go
@@ -205,7 +205,6 @@ func (r *Runner) runOnInterval(ctx context.Context) (loadtesttypes.LoadTestResul
 	if err := r.deployInitialContract(ctx); err != nil {
 		return loadtesttypes.LoadTestResult{}, err
 	}
-	r.logger.Info("Building load...", zap.Int("num_batches", r.spec.NumBatches))
 	// we build the full load upfront. that is, num_batches * [msg * msg spec amount].
 	batchLoads, err := r.buildFullLoad(ctx)
 	if err != nil {
@@ -269,7 +268,6 @@ loop:
 				}()
 			}
 
-			r.logger.Info("Load sent")
 			loadIndex++
 			if loadIndex >= len(batchLoads) {
 				// exit the loadtest loop. we have finished.
@@ -280,8 +278,10 @@ loop:
 		}
 	}
 
+	r.logger.Info("All transactions sent. Waiting for go routines to finish")
 	wg.Wait()
 	close(collectionChannel)
+	r.logger.Info("go routines have completed", zap.Int("total_txs", len(sentTxs)))
 	r.sentTxs = sentTxs
 
 	// sleep for the txs to complete.

--- a/chains/ethereum/runner/runner.go
+++ b/chains/ethereum/runner/runner.go
@@ -282,13 +282,13 @@ loop:
 
 	wg.Wait()
 	close(collectionChannel)
-
 	r.sentTxs = sentTxs
 
-	// finish. sleep for the txs to complete.
+	// sleep for the txs to complete.
+	// it is possible many txs are still in the mempool.
+	// we dont want the collector to start looking for receipts until we have given the EVM time to process. (it is a very emotional state machine)
 	waitDuration := 1 * time.Minute
 	r.logger.Info("Loadtest complete. Sleeping for all txs to complete...", zap.Duration("wait_duration", waitDuration))
-	// wait for in-flight txs but still respect ctx completion
 	timer := time.NewTimer(waitDuration)
 	select {
 	case <-timer.C:

--- a/chains/ethereum/runner/runner.go
+++ b/chains/ethereum/runner/runner.go
@@ -30,14 +30,14 @@ type Runner struct {
 	clients   []*ethclient.Client
 	wsClients []*ethclient.Client
 
-	spec          loadtesttypes.LoadTestSpec
-	nonces        *sync.Map
-	wallets       []*wallet.InteractingWallet
-	blockGasLimit int64
-	collector     metrics.Collector
+	spec      loadtesttypes.LoadTestSpec
+	nonces    *sync.Map
+	wallets   []*wallet.InteractingWallet
+	collector metrics.Collector
 
-	txFactory       *txfactory.TxFactory
-	sentTxs         []inttypes.SentTx
+	txFactory *txfactory.TxFactory
+
+	sentTxs         []*inttypes.SentTx
 	blocksProcessed uint64
 }
 
@@ -81,11 +81,10 @@ func NewRunner(ctx context.Context, logger *zap.Logger, spec loadtesttypes.LoadT
 		spec:            spec,
 		wallets:         wallets,
 		txFactory:       txf,
-		sentTxs:         make([]inttypes.SentTx, 0, 100),
+		sentTxs:         make([]*inttypes.SentTx, 0, 100),
 		blocksProcessed: 0,
 		nonces:          &nonces,
 		collector:       metrics.NewCollector(logger, clients),
-		blockGasLimit:   30_000_000, // TODO: this is just the max of ethereum. the target is 15m. max is 30m.
 	}
 
 	return r, nil
@@ -134,7 +133,201 @@ func (r *Runner) PrintResults(result loadtesttypes.LoadTestResult) {
 	r.collector.PrintResults(result)
 }
 
+// deployInitialContract deploys an initial contract, so that messages that rely on a deployed contract can run.
+func (r *Runner) deployInitialContract(ctx context.Context) error {
+	contractDeploy := loadtesttypes.LoadTestMsg{
+		Type:    inttypes.MsgCreateContract,
+		NumMsgs: 1,
+	}
+
+	txs, err := r.buildLoad(contractDeploy)
+	if err != nil {
+		return fmt.Errorf("failed to deploy contracts in PreRun: %w", err)
+	}
+	for _, tx := range txs {
+		if err := r.wallets[0].SendTransaction(ctx, tx); err != nil {
+			return fmt.Errorf("failed to send transaction in PreRun: %w", err)
+		}
+	}
+	// the loader contract embeds multiple contracts inside it to support cross-contract call
+	// load test messages. the loader contract itself is always the last tx in the group.
+	// the first txs are for the subcontracts.
+	loaderDeployTx := txs[len(txs)-1]
+	rec, err := r.wallets[0].WaitForTxReceipt(ctx, loaderDeployTx.Hash(), 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to get receipt for transaction in PreRun: %w", err)
+	}
+	r.txFactory.SetContractAddrs(rec.ContractAddress)
+	return nil
+}
+
+func (r *Runner) buildFullLoad(ctx context.Context) ([][]*gethtypes.Transaction, error) {
+	r.logger.Info("Building load...", zap.Int("num_batches", r.spec.NumBatches))
+	batchLoads := make([][]*gethtypes.Transaction, 0, 100)
+	total := 0
+	for range r.spec.NumBatches {
+		batch := make([]*gethtypes.Transaction, 0)
+		for _, msgSpec := range r.spec.Msgs {
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("ctx cancelled during load building: %w", ctx.Err())
+			default:
+			}
+			for range msgSpec.NumMsgs {
+				txs, err := r.buildLoad(msgSpec)
+				if err != nil {
+					return nil, fmt.Errorf("failed to build load for %s: %w", msgSpec.Type, err)
+				}
+				batch = append(batch, txs...)
+				total += len(txs)
+			}
+		}
+		batchLoads = append(batchLoads, batch)
+	}
+	r.logger.Info("Load built, starting loadtest", zap.Int("total_txs", total))
+	return batchLoads, nil
+}
+
 func (r *Runner) Run(ctx context.Context) (loadtesttypes.LoadTestResult, error) {
+	// when batches and interval are specified, user wants to run on a timed interval
+	if r.spec.NumBatches > 0 && r.spec.SendInterval > 0 {
+		r.logger.Info("Running loadtest on interval", zap.Duration("interval", r.spec.SendInterval), zap.Int("num_batches", r.spec.NumBatches))
+		return r.runOnInterval(ctx)
+	}
+	// otherwise we run on blocks
+	return r.runOnBlocks(ctx)
+}
+
+// runOnInterval starts the runner configured for interval load sending.
+func (r *Runner) runOnInterval(ctx context.Context) (loadtesttypes.LoadTestResult, error) {
+	// deploy an initial contract. this is needed so that messages that rely on contract calls have something
+	// to call.
+	if err := r.deployInitialContract(ctx); err != nil {
+		return loadtesttypes.LoadTestResult{}, err
+	}
+	r.logger.Info("Building load...", zap.Int("num_batches", r.spec.NumBatches))
+	// we build the full load upfront. that is, num_batches * [msg * msg spec amount].
+	batchLoads, err := r.buildFullLoad(ctx)
+	if err != nil {
+		return loadtesttypes.LoadTestResult{}, err
+	}
+	amountPerBatch := len(batchLoads[0])
+	total := len(batchLoads) * amountPerBatch
+
+	crank := time.NewTicker(r.spec.SendInterval)
+	defer crank.Stop()
+
+	// load index is the index into the batchLoads slice.
+	loadIndex := 0
+	startTime := time.Now()
+
+	// go routines will send transactions and then push results to collectionChannel.
+	mu := &sync.Mutex{}
+	sentTxs := make([]*inttypes.SentTx, 0, total)
+	collectionChannel := make(chan *inttypes.SentTx, amountPerBatch)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case tx, ok := <-collectionChannel:
+				if !ok { // channel closed
+					return
+				}
+				mu.Lock()
+				sentTxs = append(sentTxs, tx)
+				mu.Unlock()
+			}
+		}
+	}()
+
+	// waitgroup for every tx
+	wg := sync.WaitGroup{}
+
+loop:
+	for {
+		select {
+		case <-crank.C:
+			// get the load, initialize result slice.
+			load := batchLoads[loadIndex]
+			r.logger.Info("Sending txs", zap.Int("num_txs", len(load)))
+
+			// send each tx in a go routine.
+			for i, tx := range load {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					sentTx := inttypes.SentTx{Tx: tx, TxHash: tx.Hash(), MsgType: loadtesttypes.MsgType(getTxType(tx))}
+					// send the tx from a random wallet.
+					wallet := r.wallets[rand.Intn(len(r.wallets))]
+					err := wallet.SendTransaction(ctx, tx)
+					if err != nil {
+						r.logger.Error("failed to send tx", zap.Error(err), zap.Int("index", i), zap.Int("load_index", loadIndex))
+						sentTx.Err = err
+					}
+					collectionChannel <- &sentTx
+				}()
+			}
+
+			r.logger.Info("Load sent")
+			loadIndex++
+			if loadIndex >= len(batchLoads) {
+				// exit the loadtest loop. we have finished.
+				break loop
+			}
+		case <-ctx.Done(): // A channel to signal stopping the ticker
+			return loadtesttypes.LoadTestResult{}, fmt.Errorf("ctx cancelled during load firing: %w", ctx.Err())
+		}
+	}
+
+	wg.Wait()
+
+	r.sentTxs = sentTxs
+
+	// finish. sleep for the txs to complete.
+	waitDuration := 1 * time.Minute
+	r.logger.Info("Loadtest complete. Sleeping for all txs to complete...", zap.Duration("wait_duration", waitDuration))
+	// wait for in-flight txs but still respect ctx completion
+	timer := time.NewTimer(waitDuration)
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		timer.Stop()
+		r.logger.Info("Timer stopped early")
+		break
+	}
+
+	collectorStartTime := time.Now()
+
+	// build clients for collector.
+	clients := make([]wallet.Client, 0, len(r.wallets))
+	for _, wallet := range r.wallets {
+		clients = append(clients, wallet.GetClient())
+	}
+
+	// collect metrics.
+	r.logger.Info("Collecting metrics", zap.Int("num_txs", len(r.sentTxs)))
+	r.collector.GroupSentTxs(ctx, r.sentTxs, clients, startTime)
+	// we pass in 0 for the numOfBlockRequested, because we are not running a block based loadtest.
+	// The collector understands that 0 means we are on a time interval loadtest.
+	collectorResults := r.collector.ProcessResults(0)
+
+	collectorEndTime := time.Now()
+	r.logger.Debug("collector running time",
+		zap.Float64("duration_seconds", collectorEndTime.Sub(collectorStartTime).Seconds()))
+	return collectorResults, nil
+}
+
+func getTxType(tx *gethtypes.Transaction) string {
+	if tx.To() == nil {
+		return "contract_deploy"
+	}
+	return "contract_call"
+}
+
+// runOnBlocks runs the loadtest via block signal.
+// It sets up a subscription to block headers, then builds and deploys the load when it receives a header.
+func (r *Runner) runOnBlocks(ctx context.Context) (loadtesttypes.LoadTestResult, error) {
 	startTime := time.Now()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -217,7 +410,7 @@ func (r *Runner) Run(ctx context.Context) (loadtesttypes.LoadTestResult, error) 
 			clients = append(clients, wallet.GetClient())
 		}
 		r.collector.GroupSentTxs(ctx, r.sentTxs, clients, startTime)
-		collectorResults := r.collector.ProcessResults(r.blockGasLimit, r.spec.NumOfBlocks)
+		collectorResults := r.collector.ProcessResults(r.spec.NumOfBlocks)
 		collectorEndTime := time.Now()
 		r.logger.Debug("collector running time",
 			zap.Float64("duration_seconds", collectorEndTime.Sub(collectorStartTime).Seconds()))
@@ -231,7 +424,6 @@ func (r *Runner) submitLoad(ctx context.Context) (int, error) {
 	r.logger.Debug("building loads", zap.Int("num_msg_specs", len(r.spec.Msgs)))
 	txs := make([]*gethtypes.Transaction, 0, len(r.spec.Msgs))
 	for _, msgSpec := range r.spec.Msgs {
-		r.logger.Debug("building load", zap.String("type", msgSpec.Type.String()), zap.Int("num_msgs", msgSpec.NumMsgs))
 		for i := 0; i < msgSpec.NumMsgs; i++ {
 			load, err := r.buildLoad(msgSpec)
 			if err != nil {
@@ -246,7 +438,7 @@ func (r *Runner) submitLoad(ctx context.Context) (int, error) {
 
 	// submit each tx in a go routine
 	wg := sync.WaitGroup{}
-	sentTxs := make([]inttypes.SentTx, len(txs))
+	sentTxs := make([]*inttypes.SentTx, len(txs))
 	for i, tx := range txs {
 		wg.Add(1)
 		go func() {
@@ -263,7 +455,7 @@ func (r *Runner) submitLoad(ctx context.Context) (int, error) {
 			if tx.To() == nil {
 				txType = "contract_creation"
 			}
-			sentTxs[i] = inttypes.SentTx{
+			sentTxs[i] = &inttypes.SentTx{
 				TxHash:      tx.Hash(),
 				NodeAddress: "", // TODO: figure out what to do here.
 				MsgType:     loadtesttypes.MsgType(txType),

--- a/chains/ethereum/runner/runner.go
+++ b/chains/ethereum/runner/runner.go
@@ -64,7 +64,7 @@ func NewRunner(ctx context.Context, logger *zap.Logger, spec loadtesttypes.LoadT
 		return nil, err
 	}
 
-	txf := txfactory.NewTxFactory(logger, wallets, chainCfg.MaxContracts)
+	txf := txfactory.NewTxFactory(logger, wallets, chainCfg.MaxContracts, chainCfg.TxOpts)
 	nonces := sync.Map{}
 	for _, wallet := range wallets {
 		nonce, err := wallet.GetNonce(ctx)
@@ -165,7 +165,7 @@ func (r *Runner) buildFullLoad(ctx context.Context) ([][]*gethtypes.Transaction,
 	r.logger.Info("Building load...", zap.Int("num_batches", r.spec.NumBatches))
 	batchLoads := make([][]*gethtypes.Transaction, 0, 100)
 	total := 0
-	for range r.spec.NumBatches {
+	for i := range r.spec.NumBatches {
 		batch := make([]*gethtypes.Transaction, 0)
 		for _, msgSpec := range r.spec.Msgs {
 			select {
@@ -182,6 +182,7 @@ func (r *Runner) buildFullLoad(ctx context.Context) ([][]*gethtypes.Transaction,
 				total += len(txs)
 			}
 		}
+		r.logger.Info(fmt.Sprintf("built batch %d/%d", i+1, r.spec.NumBatches))
 		batchLoads = append(batchLoads, batch)
 	}
 	r.logger.Info("Load built, starting loadtest", zap.Int("total_txs", total))

--- a/chains/ethereum/runner/runner.go
+++ b/chains/ethereum/runner/runner.go
@@ -281,6 +281,7 @@ loop:
 	}
 
 	wg.Wait()
+	close(collectionChannel)
 
 	r.sentTxs = sentTxs
 

--- a/chains/ethereum/txfactory/factory.go
+++ b/chains/ethereum/txfactory/factory.go
@@ -166,7 +166,7 @@ func (f *TxFactory) createMsgCreateContract(ctx context.Context, fromWallet *eth
 
 func (f *TxFactory) createMsgWriteTo(ctx context.Context, fromWallet *ethwallet.InteractingWallet, iterations int, nonce uint64, useBaseline bool) (*types.Transaction, error) {
 	if iterations <= 0 {
-		iterations = 3
+		iterations = 1
 	}
 	if len(f.contractAddresses) == 0 {
 		f.logger.Debug("no contract addresses for tx")

--- a/chains/ethereum/txfactory/factory.go
+++ b/chains/ethereum/txfactory/factory.go
@@ -76,7 +76,7 @@ func (f *TxFactory) createMsgCreateContract(ctx context.Context, fromWallet *eth
 		numTargets = *targets
 	} else {
 		// add 1 so we never get 0. can be 1-3.
-		numTargets = rand.Intn(3) + 1
+		numTargets = 2
 	}
 
 	// Deploy target contracts first
@@ -151,11 +151,11 @@ func (f *TxFactory) updateContractAddressesAsync(ctx context.Context, txHash com
 }
 
 func (f *TxFactory) createMsgWriteTo(ctx context.Context, fromWallet *ethwallet.InteractingWallet, iterations int, nonce uint64) (*types.Transaction, error) {
-	// Default to 100 iterations if not specified
 	if iterations <= 0 {
-		iterations = rand.Intn(3) + 1
+		iterations = 3
 	}
 	if len(f.contractAddresses) == 0 {
+		f.logger.Debug("no contract addresses for tx")
 		return nil, nil
 	}
 

--- a/chains/ethereum/txfactory/factory.go
+++ b/chains/ethereum/txfactory/factory.go
@@ -83,11 +83,13 @@ func (f *TxFactory) createMsgCreateContract(ctx context.Context, fromWallet *eth
 	targetContractAddrs := make([]common.Address, 0, numTargets)
 	for i := 0; i < numTargets; i++ {
 		addr, tx, _, err := target.DeployTarget(&bind.TransactOpts{
-			From:    fromWallet.Address(),
-			Signer:  fromWallet.SignerFnLegacy(),
-			Nonce:   big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
-			Context: ctx,
-			NoSend:  true,
+			From:      fromWallet.Address(),
+			Signer:    fromWallet.SignerFnLegacy(),
+			Nonce:     big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
+			GasTipCap: big.NewInt(1000 * 1e9),
+			GasFeeCap: big.NewInt(1000 * 1e9),
+			Context:   ctx,
+			NoSend:    true,
 		}, fromWallet.GetClient())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create target contract transaction: %w", err)
@@ -97,11 +99,13 @@ func (f *TxFactory) createMsgCreateContract(ctx context.Context, fromWallet *eth
 		nonce++
 	}
 	_, loaderDeployTx, _, err := loader.DeployLoader(&bind.TransactOpts{
-		From:    fromWallet.Address(),
-		Signer:  fromWallet.SignerFnLegacy(),
-		Nonce:   big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
-		Context: ctx,
-		NoSend:  true,
+		From:      fromWallet.Address(),
+		Signer:    fromWallet.SignerFnLegacy(),
+		Nonce:     big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
+		GasTipCap: big.NewInt(1000 * 1e9),
+		GasFeeCap: big.NewInt(1000 * 1e9),
+		Context:   ctx,
+		NoSend:    true,
 	}, fromWallet.GetClient(), targetContractAddrs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create loader contract transaction: %w", err)
@@ -160,11 +164,13 @@ func (f *TxFactory) createMsgWriteTo(ctx context.Context, fromWallet *ethwallet.
 		return nil, fmt.Errorf("failed to get loader contract instance at %s: %w", contractAddr.String(), err)
 	}
 	tx, err := loaderInstance.TestStorageWrites(&bind.TransactOpts{
-		From:    fromWallet.Address(),
-		Signer:  fromWallet.SignerFnLegacy(),
-		Nonce:   big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
-		Context: ctx,
-		NoSend:  true,
+		From:      fromWallet.Address(),
+		Signer:    fromWallet.SignerFnLegacy(),
+		Nonce:     big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
+		GasTipCap: big.NewInt(1000 * 1e9),
+		GasFeeCap: big.NewInt(1000 * 1e9),
+		Context:   ctx,
+		NoSend:    true,
 	}, big.NewInt(int64(iterations)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build tx for writeTo function at %s: %w", contractAddr.String(), err)
@@ -193,11 +199,13 @@ func (f *TxFactory) createMsgCallDataBlast(ctx context.Context, fromWallet *ethw
 		return nil, fmt.Errorf("failed to get loader contract instance at %s: %w", contractAddr.String(), err)
 	}
 	tx, err := loaderInstance.TestLargeCalldata(&bind.TransactOpts{
-		From:    fromWallet.Address(),
-		Signer:  fromWallet.SignerFnLegacy(),
-		Context: ctx,
-		Nonce:   big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
-		NoSend:  true,
+		From:      fromWallet.Address(),
+		Signer:    fromWallet.SignerFnLegacy(),
+		Context:   ctx,
+		GasTipCap: big.NewInt(1000 * 1e9),
+		GasFeeCap: big.NewInt(1000 * 1e9),
+		Nonce:     big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
+		NoSend:    true,
 	}, randomBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build tx for testLargeCallData function at %s: %w", contractAddr.String(), err)
@@ -222,11 +230,13 @@ func (f *TxFactory) createMsgCrossContractCall(ctx context.Context, fromWallet *
 		return nil, fmt.Errorf("failed to get loader contract instance at %s: %w", contractAddr.String(), err)
 	}
 	tx, err := loaderInstance.TestCrossContractCalls(&bind.TransactOpts{
-		From:    fromWallet.Address(),
-		Signer:  fromWallet.SignerFnLegacy(),
-		Nonce:   big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
-		Context: ctx,
-		NoSend:  true,
+		From:      fromWallet.Address(),
+		Signer:    fromWallet.SignerFnLegacy(),
+		GasTipCap: big.NewInt(1000 * 1e9),
+		GasFeeCap: big.NewInt(1000 * 1e9),
+		Nonce:     big.NewInt(int64(nonce)), //nolint:gosec // G115: overflow unlikely in practice
+		Context:   ctx,
+		NoSend:    true,
 	}, big.NewInt(int64(iterations)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to build tx for writeTo function at %s: %w", contractAddr.String(), err)

--- a/chains/ethereum/txfactory/factory_test.go
+++ b/chains/ethereum/txfactory/factory_test.go
@@ -23,10 +23,10 @@ func TestCreateContract_SuccessfulTxs(t *testing.T) {
 	for range 10 {
 		sim, wallet := setupTest(t)
 		ctx := context.Background()
-		f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
+		f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, ethtypes.TxOpts{})
 		nonce, err := wallet.GetNonce(ctx)
 		require.NoError(t, err)
-		txs, err := f.createMsgCreateContract(ctx, wallet, nil, nonce)
+		txs, err := f.createMsgCreateContract(ctx, wallet, nil, nonce, false)
 		require.NoError(t, err)
 
 		for _, tx := range txs {
@@ -49,12 +49,12 @@ func TestCreateMsgWriteTo(t *testing.T) {
 
 	sim, wallet := setupTest(t)
 	ctx := context.Background()
-	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
+	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, ethtypes.TxOpts{})
 	deployContract(t, sim, f)
 
 	nonce, err := wallet.GetNonce(ctx)
 	require.NoError(t, err)
-	tx, err := f.createMsgWriteTo(ctx, wallet, 100, nonce)
+	tx, err := f.createMsgWriteTo(ctx, wallet, 100, nonce, false)
 	require.NoError(t, err)
 	err = wallet.SendTransaction(ctx, tx)
 	require.NoError(t, err)
@@ -76,12 +76,12 @@ func TestCallDataBlast(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	sim, wallet := setupTest(t)
 	ctx := context.Background()
-	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
+	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, ethtypes.TxOpts{})
 	deployContract(t, sim, f)
 
 	nonce, err := wallet.GetNonce(ctx)
 	require.NoError(t, err)
-	tx, err := f.createMsgCallDataBlast(ctx, wallet, 1024, nonce)
+	tx, err := f.createMsgCallDataBlast(ctx, wallet, 1024, nonce, false)
 	require.NoError(t, err)
 	err = wallet.SendTransaction(ctx, tx)
 	require.NoError(t, err)
@@ -95,12 +95,12 @@ func TestCrossContractCall(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	sim, wallet := setupTest(t)
 	ctx := context.Background()
-	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
+	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, ethtypes.TxOpts{})
 	deployContract(t, sim, f)
 
 	nonce, err := wallet.GetNonce(ctx)
 	require.NoError(t, err)
-	tx, err := f.createMsgCrossContractCall(ctx, wallet, 15, nonce)
+	tx, err := f.createMsgCrossContractCall(ctx, wallet, 15, nonce, false)
 	require.NoError(t, err)
 	err = wallet.SendTransaction(ctx, tx)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func deployContract(t *testing.T, sim *simulated.Backend, f *TxFactory) {
 	wallet := f.wallets[0]
 	nonce, err := wallet.GetNonce(ctx)
 	require.NoError(t, err)
-	txs, err := f.createMsgCreateContract(ctx, wallet, &numContracts, nonce)
+	txs, err := f.createMsgCreateContract(ctx, wallet, &numContracts, nonce, false)
 	require.NoError(t, err)
 	for _, tx := range txs {
 		err = wallet.SendTransaction(ctx, tx)

--- a/chains/ethereum/txfactory/factory_test.go
+++ b/chains/ethereum/txfactory/factory_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
 	loader "github.com/skip-mev/catalyst/chains/ethereum/contracts/load"
 	"github.com/skip-mev/catalyst/chains/ethereum/contracts/load/target"
+	ethtypes "github.com/skip-mev/catalyst/chains/ethereum/types"
 	ethwallet "github.com/skip-mev/catalyst/chains/ethereum/wallet"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -22,7 +23,7 @@ func TestCreateContract_SuccessfulTxs(t *testing.T) {
 	for range 10 {
 		sim, wallet := setupTest(t)
 		ctx := context.Background()
-		f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0)
+		f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
 		nonce, err := wallet.GetNonce(ctx)
 		require.NoError(t, err)
 		txs, err := f.createMsgCreateContract(ctx, wallet, nil, nonce)
@@ -48,7 +49,7 @@ func TestCreateMsgWriteTo(t *testing.T) {
 
 	sim, wallet := setupTest(t)
 	ctx := context.Background()
-	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0)
+	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
 	deployContract(t, sim, f)
 
 	nonce, err := wallet.GetNonce(ctx)
@@ -75,7 +76,7 @@ func TestCallDataBlast(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	sim, wallet := setupTest(t)
 	ctx := context.Background()
-	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0)
+	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
 	deployContract(t, sim, f)
 
 	nonce, err := wallet.GetNonce(ctx)
@@ -94,7 +95,7 @@ func TestCrossContractCall(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	sim, wallet := setupTest(t)
 	ctx := context.Background()
-	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0)
+	f := NewTxFactory(logger, []*ethwallet.InteractingWallet{wallet}, 0, ethtypes.TxOpts{})
 	deployContract(t, sim, f)
 
 	nonce, err := wallet.GetNonce(ctx)

--- a/chains/ethereum/types/types.go
+++ b/chains/ethereum/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -33,11 +34,19 @@ type NodeAddress struct {
 	Websocket string `yaml:"websocket"`
 }
 
+type TxOpts struct {
+	GasPrice  *big.Int `yaml:"gas_price" json:"gas_price"`
+	GasFeeCap *big.Int `yaml:"gas_fee_cap" json:"gas_fee_cap"`
+	GasTipCap *big.Int `yaml:"gas_tip_cap" json:"gas_tip_cap"`
+}
+
 type ChainConfig struct {
 	NodesAddresses []NodeAddress `yaml:"nodes_addresses" json:"NodesAddresses"`
 	// MaxContracts is the maximum number of contracts that the loadtest runner will hold in memory.
 	// The contracts in memory are used for the other load test message types to interact with.
 	MaxContracts uint64 `yaml:"max_contracts" json:"MaxContracts"`
+
+	TxOpts TxOpts `yaml:"tx_opts" json:"TxOpts"`
 }
 
 func init() {

--- a/chains/ethereum/types/types.go
+++ b/chains/ethereum/types/types.go
@@ -20,6 +20,8 @@ const (
 	MsgCallDataBlast loadtesttypes.MsgType = "MsgCallDataBlast"
 )
 
+var ValidMessages = []loadtesttypes.MsgType{MsgCreateContract, MsgWriteTo, MsgCrossContractCall, MsgCallDataBlast}
+
 type SentTx struct {
 	TxHash      common.Hash
 	NodeAddress string
@@ -44,8 +46,8 @@ type ChainConfig struct {
 	NodesAddresses []NodeAddress `yaml:"nodes_addresses" json:"NodesAddresses"`
 	// MaxContracts is the maximum number of contracts that the loadtest runner will hold in memory.
 	// The contracts in memory are used for the other load test message types to interact with.
-	MaxContracts uint64 `yaml:"max_contracts" json:"MaxContracts"`
-
+	NumInitialContracts uint64 `yaml:"num_initial_contracts" json:"NumInitialContracts"`
+	// Static gas options for transactions.
 	TxOpts TxOpts `yaml:"tx_opts" json:"TxOpts"`
 }
 

--- a/chains/types/spec.go
+++ b/chains/types/spec.go
@@ -8,16 +8,18 @@ import (
 )
 
 type LoadTestSpec struct {
-	Name        string        `yaml:"name" json:"name"`
-	Description string        `yaml:"description" json:"description"`
-	Kind        string        `yaml:"kind" json:"kind"` // "cosmos" | "evm" (discriminator)
-	ChainID     string        `yaml:"chain_id" json:"chain_id"`
-	NumOfTxs    int           `yaml:"num_of_txs,omitempty" json:"num_of_txs,omitempty"`
-	NumOfBlocks int           `yaml:"num_of_blocks" json:"num_of_blocks"`
-	Mnemonics   []string      `yaml:"mnemonics" json:"mnemonics"`
-	Msgs        []LoadTestMsg `yaml:"msgs" json:"msgs"`
-	TxTimeout   time.Duration `yaml:"tx_timeout,omitempty" json:"tx_timeout,omitempty"`
-	ChainCfg    ChainConfig   `yaml:"-" json:"-"` // decoded via custom UnmarshalYAML
+	Name         string        `yaml:"name" json:"name"`
+	Description  string        `yaml:"description" json:"description"`
+	Kind         string        `yaml:"kind" json:"kind"` // "cosmos" | "evm" (discriminator)
+	ChainID      string        `yaml:"chain_id" json:"chain_id"`
+	NumOfTxs     int           `yaml:"num_of_txs,omitempty" json:"num_of_txs,omitempty"`
+	NumOfBlocks  int           `yaml:"num_of_blocks" json:"num_of_blocks"`
+	SendInterval time.Duration `yaml:"send_interval" json:"send_interval"`
+	NumBatches   int           `yaml:"num_batches" json:"num_batches"`
+	Mnemonics    []string      `yaml:"mnemonics" json:"mnemonics"`
+	Msgs         []LoadTestMsg `yaml:"msgs" json:"msgs"`
+	TxTimeout    time.Duration `yaml:"tx_timeout,omitempty" json:"tx_timeout,omitempty"`
+	ChainCfg     ChainConfig   `yaml:"-" json:"-"` // decoded via custom UnmarshalYAML
 }
 
 type loadTestSpecAlias LoadTestSpec

--- a/chains/types/spec.go
+++ b/chains/types/spec.go
@@ -63,14 +63,6 @@ func (s *LoadTestSpec) Validate() error {
 		return fmt.Errorf("chain ID must be specified")
 	}
 
-	if s.NumOfTxs <= 0 {
-		return fmt.Errorf("num_of_txs must be greater than 0")
-	}
-
-	if s.NumOfBlocks <= 0 {
-		return fmt.Errorf("num_of_blocks must be greater than 0")
-	}
-
 	if len(s.Msgs) == 0 {
 		return fmt.Errorf("no messages specified for load testing")
 	}

--- a/chains/types/spec_test.go
+++ b/chains/types/spec_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
@@ -39,6 +40,37 @@ func TestLoadTestSpec_Marshal_Unmarshal_Eth(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, spec, otherLoadtestSpec)
+}
+
+func TestEthereum(t *testing.T) {
+	yml := []byte(`
+name: worker
+description: eth load test
+kind: eth
+chain_id: 2341
+num_of_blocks: 200
+mnemonics: ["seed phrase goes here"]
+tx_timeout: "30s"
+chain_config:
+  tx_opts:
+    gas_fee_cap: 1000000000000
+    gas_tip_cap: 1000000000000
+`)
+
+	var spec loadtesttypes.LoadTestSpec
+
+	if err := yaml.Unmarshal(yml, &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v", err)
+	}
+
+	cfg, ok := spec.ChainCfg.(*ethtypes.ChainConfig)
+	require.True(t, ok)
+	expectedTxOpts := ethtypes.TxOpts{
+		GasPrice:  nil,
+		GasFeeCap: big.NewInt(1000000000000),
+		GasTipCap: big.NewInt(1000000000000),
+	}
+	require.Equal(t, expectedTxOpts, cfg.TxOpts)
 }
 
 func TestLoadTestSpec_Unmarshal_Cosmos(t *testing.T) {

--- a/example/loadtest_eth.yml
+++ b/example/loadtest_eth.yml
@@ -3,22 +3,18 @@ name: "eth_loadtest"
 description: "testing"
 kind: "eth"
 chain_id: "262144"
-num_of_txs: 50     # transactions per block
-num_of_blocks: 50  # Process 100 blocks
+send_interval: 1.5s
+num_batches: 15
+msgs:
+  - type: "MsgCreateContract"
+    num_msgs: 3
+  - type: "MsgWriteTo"
+    num_msgs: 5
 mnemonics:
   - "copper push brief egg scan entry inform record adjust fossil boss egg comic alien upon aspect dry avoid interest fury window hint race symptom"
   - "maximum display century economy unlock van census kite error heart snow filter midnight usage egg venture cash kick motor survey drastic edge muffin visual"
   - "will wear settle write dance topic tape sea glory hotel oppose rebel client problem era video gossip glide during yard balance cancel file rose"
   - "doll midnight silk carpet brush boring pluck office gown inquiry duck chief aim exit gain never tennis crime fragile ship cloud surface exotic patch"
-msgs:
-  - type: "MsgCreateContract"
-    num_msgs: 20
-  - type: "MsgWriteTo"
-    num_msgs: 20
-  - type: "MsgCrossContractCall"
-    num_msgs: 20
-  - type: "MsgCallDataBlast"
-    num_msgs: 20
 chain_config:
   nodes_addresses:
     - rpc: "http://localhost:8545"


### PR DESCRIPTION
allows the ethereum load test runner to be configured to run on a timer, rather than a block subscription.

config:
```
# Example load test configuration
name: "eth_loadtest"
description: "testing"
kind: "eth"
chain_id: "262144"
num_of_txs: 20    # this doesnt matter
num_of_blocks: 20  # Process 100 blocks
send_interval: 2s
num_batches: 20
msgs:
  - type: "MsgCreateContract"
    num_msgs: 3
  - type: "MsgWriteTo"
    num_msgs: 450
chain_config:
  nodes_addresses:
    - rpc: "http://localhost:8545"
      websocket: "ws://localhost:8546"
```