### PR TITLE
fix: wait for all node mempool to clear

### DIFF
--- a/chains/ethereum/metrics/collector.go
+++ b/chains/ethereum/metrics/collector.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/skip-mev/catalyst/chains/ethereum/types"
 	"github.com/skip-mev/catalyst/chains/ethereum/wallet"
 	loadtesttypes "github.com/skip-mev/catalyst/chains/types"
@@ -18,7 +19,7 @@ import (
 )
 
 // ProcessResults processes the results of the load test.
-func ProcessResults(ctx context.Context, logger *zap.Logger, sentTxs []*types.SentTx, startBlock, endBlock uint64, clients []wallet.Client) (*loadtesttypes.LoadTestResult, error) {
+func ProcessResults(ctx context.Context, logger *zap.Logger, sentTxs []*types.SentTx, startBlock, endBlock uint64, clients []*ethclient.Client) (*loadtesttypes.LoadTestResult, error) {
 	wg := sync.WaitGroup{}
 	blockStats := make([]loadtesttypes.BlockStat, endBlock-startBlock+1)
 	receipts := make(map[uint64]gethtypes.Receipts)

--- a/chains/ethereum/runner/runner.go
+++ b/chains/ethereum/runner/runner.go
@@ -365,18 +365,12 @@ loop:
 	}
 	endingBlock := blockNum
 
-	// build clients for collector.
-	clients := make([]wallet.Client, 0, len(r.wallets))
-	for _, wallet := range r.wallets {
-		clients = append(clients, wallet.GetClient())
-	}
-
 	// collect metrics.
 	r.logger.Info("Collecting metrics", zap.Int("num_txs", len(r.sentTxs)))
 	// we pass in 0 for the numOfBlockRequested, because we are not running a block based loadtest.
 	// The collector understands that 0 means we are on a time interval loadtest.
 	collectorStartTime := time.Now()
-	collectorResults, err := metrics.ProcessResults(ctx, r.logger, r.sentTxs, startingBlock, endingBlock, clients)
+	collectorResults, err := metrics.ProcessResults(ctx, r.logger, r.sentTxs, startingBlock, endingBlock, r.clients)
 	if err != nil {
 		return loadtesttypes.LoadTestResult{}, fmt.Errorf("failed to collect metrics: %w", err)
 	}
@@ -472,11 +466,7 @@ func (r *Runner) runOnBlocks(ctx context.Context) (loadtesttypes.LoadTestResult,
 		r.waitForEmptyMempool(ctx, 1*time.Minute)
 
 		collectorStartTime := time.Now()
-		clients := make([]wallet.Client, 0, len(r.wallets))
-		for _, wallet := range r.wallets {
-			clients = append(clients, wallet.GetClient())
-		}
-		collectorResults, err := metrics.ProcessResults(ctx, r.logger, r.sentTxs, startingBlock, endingBlock, clients)
+		collectorResults, err := metrics.ProcessResults(ctx, r.logger, r.sentTxs, startingBlock, endingBlock, r.clients)
 		if err != nil {
 			return loadtesttypes.LoadTestResult{Error: err.Error()}, fmt.Errorf("failed to collect metrics: %w", err)
 		}


### PR DESCRIPTION
previously `waitForEmptyMempool` would just wait on one node's mempool to clear. this changes that to wait for ALL mempools pending txs to clear.