### PR TITLE
fix: tps calculation

### DIFF
--- a/chains/ethereum/metrics/collector.go
+++ b/chains/ethereum/metrics/collector.go
@@ -184,13 +184,17 @@ func getReceiptsForBlockTxs(ctx context.Context, block *gethtypes.Block, client 
 }
 
 func trimBlocks(blocks []loadtesttypes.BlockStat) ([]loadtesttypes.BlockStat, error) {
-	endTxIndex := len(blocks) - 1
+	endTxIndex := -1
 	for i := len(blocks) - 1; i >= 0; i-- {
 		if len(blocks[i].MessageStats) == 0 {
 			continue
 		}
 		endTxIndex = i
 		break
+	}
+
+	if endTxIndex == -1 {
+		return nil, fmt.Errorf("no blocks with transactions")
 	}
 
 	startTxIndex := 0
@@ -200,10 +204,6 @@ func trimBlocks(blocks []loadtesttypes.BlockStat) ([]loadtesttypes.BlockStat, er
 		}
 		startTxIndex = i
 		break
-	}
-
-	if startTxIndex > endTxIndex {
-		return nil, fmt.Errorf("no blocks with transactions")
 	}
 
 	// Include one block before the first transaction block for TPS calculation

--- a/chains/ethereum/metrics/collector.go
+++ b/chains/ethereum/metrics/collector.go
@@ -209,7 +209,7 @@ func trimBlocks(blocks []loadtesttypes.BlockStat) ([]loadtesttypes.BlockStat, er
 	// Include one block before the first transaction block for TPS calculation
 	// This ensures we have a proper time span when all transactions are in one block
 	if startTxIndex > 0 {
-		startTxIndex = startTxIndex - 1
+		startTxIndex--
 	}
 
 	return blocks[startTxIndex : endTxIndex+1], nil

--- a/chains/ethereum/metrics/collector_test.go
+++ b/chains/ethereum/metrics/collector_test.go
@@ -1,0 +1,171 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	loadtesttypes "github.com/skip-mev/catalyst/chains/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrimBlocks(t *testing.T) {
+	tests := []struct {
+		name        string
+		blocks      []loadtesttypes.BlockStat
+		expected    []loadtesttypes.BlockStat
+		expectError bool
+	}{
+		{
+			name: "single block with transactions - preserves previous block",
+			blocks: []loadtesttypes.BlockStat{
+				{
+					BlockHeight:  1,
+					Timestamp:    time.Now().Add(-20 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{}, // empty
+				},
+				{
+					BlockHeight: 2,
+					Timestamp:   time.Now().Add(-10 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 1}, // has transactions
+					},
+				},
+				{
+					BlockHeight:  3,
+					Timestamp:    time.Now(),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{}, // empty
+				},
+			},
+			expected: []loadtesttypes.BlockStat{
+				{
+					BlockHeight:  1,
+					Timestamp:    time.Now().Add(-20 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{},
+				},
+				{
+					BlockHeight: 2,
+					Timestamp:   time.Now().Add(-10 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 1},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "first block has transactions - no previous block to preserve",
+			blocks: []loadtesttypes.BlockStat{
+				{
+					BlockHeight: 1,
+					Timestamp:   time.Now().Add(-10 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 1}, // has transactions
+					},
+				},
+				{
+					BlockHeight:  2,
+					Timestamp:    time.Now(),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{}, // empty
+				},
+			},
+			expected: []loadtesttypes.BlockStat{
+				{
+					BlockHeight: 1,
+					Timestamp:   time.Now().Add(-10 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 1},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple blocks with transactions",
+			blocks: []loadtesttypes.BlockStat{
+				{
+					BlockHeight:  1,
+					Timestamp:    time.Now().Add(-30 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{}, // empty
+				},
+				{
+					BlockHeight: 2,
+					Timestamp:   time.Now().Add(-20 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 1}, // has transactions
+					},
+				},
+				{
+					BlockHeight: 3,
+					Timestamp:   time.Now().Add(-10 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 2}, // has transactions
+					},
+				},
+				{
+					BlockHeight:  4,
+					Timestamp:    time.Now(),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{}, // empty
+				},
+			},
+			expected: []loadtesttypes.BlockStat{
+				{
+					BlockHeight:  1,
+					Timestamp:    time.Now().Add(-30 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{},
+				},
+				{
+					BlockHeight: 2,
+					Timestamp:   time.Now().Add(-20 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 1},
+					},
+				},
+				{
+					BlockHeight: 3,
+					Timestamp:   time.Now().Add(-10 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{
+						"test": {SuccessfulTxs: 2},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "no blocks with transactions - should return error",
+			blocks: []loadtesttypes.BlockStat{
+				{
+					BlockHeight:  1,
+					Timestamp:    time.Now().Add(-20 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{}, // empty
+				},
+				{
+					BlockHeight:  2,
+					Timestamp:    time.Now().Add(-10 * time.Second),
+					MessageStats: map[loadtesttypes.MsgType]loadtesttypes.MessageBlockStats{}, // empty
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := trimBlocks(tt.blocks)
+
+			if tt.expectError {
+				require.Error(t, err, "Expected error but got none")
+				require.Nil(t, result, "Expected nil result when error occurs")
+				require.Contains(t, err.Error(), "no blocks with transactions", "Error message should contain expected text")
+			} else {
+				require.NoError(t, err, "Expected no error but got: %v", err)
+				require.Equal(t, len(tt.expected), len(result), "Length should match")
+
+				for i, expected := range tt.expected {
+					require.Equal(t, expected.BlockHeight, result[i].BlockHeight, "Block height should match")
+					require.Equal(t, len(expected.MessageStats), len(result[i].MessageStats), "MessageStats length should match")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
previously if all txs were in one block, this would cause an error:

`runner results {"resultsError": "json: unsupported value: NaN"}`

trying to divide by 0 here https://github.com/skip-mev/catalyst/blob/62cbe633212b7944b6b7c15de510d8f15448ab09/chains/ethereum/metrics/collector.go#L118

since endTime and startTime are the same in this case if there was only one block.

if there are multiple blocks, I believe the previous logic incorrectly ignored the time it took for the first block with transactions to run as well. the new calculation starts from the timestamp of the previous block to fix this
