### PR TITLE
chore: add error to config error

### DIFF
--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	if err := spec.Validate(); err != nil {
-		saveConfigError("failed to validate config file", logger)
+		saveConfigError("failed to validate config file: "+err.Error(), logger)
 		logger.Fatal("failed to validate config file", zap.Error(err))
 	}
 


### PR DESCRIPTION
previously the saved error didn't include the actual error. now it does