### PR TITLE
perf(persistent): Do not wait for response from `eth_SendRawTransaction` when metrics are not enabled

### DIFF
--- a/chains/ethereum/runner/persistent.go
+++ b/chains/ethereum/runner/persistent.go
@@ -176,7 +176,12 @@ func (r *Runner) submitLoadPersistent(
 		wg.Go(func() {
 			// send the tx from the wallet assigned to this transaction's sender
 			fromWallet := r.getWalletForTx(tx)
-			err := fromWallet.SendTransaction(ctx, tx)
+			var err error
+			if r.spec.MetricsEnabled {
+				err = fromWallet.SendTransaction(ctx, tx)
+			} else {
+				err = fromWallet.NotifySendTransaction(ctx, tx)
+			}
 			if err != nil {
 				r.logger.Info("failed to send transaction", zap.String("tx_hash", tx.Hash().String()), zap.Error(err))
 				r.promMetrics.BroadcastFailure.Add(1)

--- a/chains/ethereum/runner/persistent.go
+++ b/chains/ethereum/runner/persistent.go
@@ -179,14 +179,14 @@ func (r *Runner) submitLoadPersistent(
 			var err error
 			if r.spec.MetricsEnabled {
 				err = fromWallet.SendTransaction(ctx, tx)
+				if err != nil {
+					r.logger.Info("failed to send transaction", zap.String("tx_hash", tx.Hash().String()), zap.Error(err))
+					r.promMetrics.BroadcastFailure.Add(1)
+				} else {
+					r.promMetrics.BroadcastSuccess.Add(1)
+				}
 			} else {
-				err = fromWallet.NotifySendTransaction(ctx, tx)
-			}
-			if err != nil {
-				r.logger.Info("failed to send transaction", zap.String("tx_hash", tx.Hash().String()), zap.Error(err))
-				r.promMetrics.BroadcastFailure.Add(1)
-			} else {
-				r.promMetrics.BroadcastSuccess.Add(1)
+				fromWallet.SendTransactionAsync(ctx, tx)
 			}
 
 			txType := inttypes.ContractCall

--- a/chains/ethereum/runner/persistent.go
+++ b/chains/ethereum/runner/persistent.go
@@ -221,7 +221,9 @@ func (r *Runner) sendAndRecord(ctx context.Context, tracker *orderedmap.OrderedM
 func (r *Runner) sendAsync(ctx context.Context, txs gethtypes.Transactions) {
 	for _, tx := range txs {
 		fromWallet := r.getWalletForTx(tx)
-		go fromWallet.SendTransaction(ctx, tx)
+		go func() {
+			_ = fromWallet.SendTransaction(ctx, tx)
+		}()
 	}
 }
 

--- a/chains/ethereum/runner/persistent.go
+++ b/chains/ethereum/runner/persistent.go
@@ -182,7 +182,11 @@ func (r *Runner) submitLoadPersistent(
 // sendAndRecord sends transactions inside of goroutines, and waits for each
 // send to complete, recording metrics about the outcome of each send in the
 // tracker and via Prometheus.
-func (r *Runner) sendAndRecord(ctx context.Context, tracker *orderedmap.OrderedMap[common.Hash, time.Time], txs gethtypes.Transactions) {
+func (r *Runner) sendAndRecord(
+	ctx context.Context,
+	tracker *orderedmap.OrderedMap[common.Hash, time.Time],
+	txs gethtypes.Transactions,
+) {
 	sentTxs := make([]*inttypes.SentTx, len(txs))
 	var wg sync.WaitGroup
 	for i, tx := range txs {

--- a/chains/ethereum/wallet/wallet.go
+++ b/chains/ethereum/wallet/wallet.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -323,6 +324,19 @@ func (w *InteractingWallet) CreateSignedDynamicFeeTx(ctx context.Context, to *co
 // SendTransaction broadcasts a signed transaction to the network
 func (w *InteractingWallet) SendTransaction(ctx context.Context, signedTx *types.Transaction) error {
 	return w.client.SendTransaction(ctx, signedTx)
+}
+
+// NotifySendTransaction broadcasts a signed transaction without waiting for a response.
+func (w *InteractingWallet) NotifySendTransaction(ctx context.Context, signedTx *types.Transaction) error {
+	data, err := signedTx.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	ec, ok := w.client.(*ethclient.Client)
+	if !ok {
+		return w.client.SendTransaction(ctx, signedTx)
+	}
+	return ec.Client().Notify(ctx, "eth_sendRawTransaction", hexutil.Encode(data))
 }
 
 // CreateAndSendTransaction creates, signs, and sends a transaction in one call

--- a/chains/ethereum/wallet/wallet.go
+++ b/chains/ethereum/wallet/wallet.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -326,17 +325,9 @@ func (w *InteractingWallet) SendTransaction(ctx context.Context, signedTx *types
 	return w.client.SendTransaction(ctx, signedTx)
 }
 
-// NotifySendTransaction broadcasts a signed transaction without waiting for a response.
-func (w *InteractingWallet) NotifySendTransaction(ctx context.Context, signedTx *types.Transaction) error {
-	data, err := signedTx.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	ec, ok := w.client.(*ethclient.Client)
-	if !ok {
-		return w.client.SendTransaction(ctx, signedTx)
-	}
-	return ec.Client().Notify(ctx, "eth_sendRawTransaction", hexutil.Encode(data))
+// SendTransactionAsync broadcasts a signed transaction without waiting for the response.
+func (w *InteractingWallet) SendTransactionAsync(ctx context.Context, signedTx *types.Transaction) {
+	go w.client.SendTransaction(ctx, signedTx)
 }
 
 // CreateAndSendTransaction creates, signs, and sends a transaction in one call

--- a/chains/ethereum/wallet/wallet.go
+++ b/chains/ethereum/wallet/wallet.go
@@ -325,11 +325,6 @@ func (w *InteractingWallet) SendTransaction(ctx context.Context, signedTx *types
 	return w.client.SendTransaction(ctx, signedTx)
 }
 
-// SendTransactionAsync broadcasts a signed transaction without waiting for the response.
-func (w *InteractingWallet) SendTransactionAsync(ctx context.Context, signedTx *types.Transaction) {
-	go w.client.SendTransaction(ctx, signedTx)
-}
-
 // CreateAndSendTransaction creates, signs, and sends a transaction in one call
 func (w *InteractingWallet) CreateAndSendTransaction(ctx context.Context, to *common.Address, value *big.Int,
 	gasLimit uint64, gasPrice *big.Int, data []byte, nonce *uint64,


### PR DESCRIPTION
Optimization for the persistent runner to work with the new `eth_SendTransaction` semantics. `eth_SendTransaction` will wait for the transaction to be inserted into the mempool before returning from the response to the RPC caller. This may have a non negligible delay since the insert queue may have transaction ahead of this tx, and it needs to acquire a high contention lock in order to insert (that is held longer and longer as tx count in the mempool grows, compounding the issue). 

This modifies the sending logic to simply not wait for this (potentially) long delay before moving on with sending new txs. The response from the mempool insert (the response from `eth_SendTransaction` or `fromWallet.SendTransaction`) was only used to record metrics (broadcast success/failure metrics and txtracker metrics for inclusion time), so if metrics are disabled, we opt to use this non blocking method of sending instead. 

Closes: STACK-2303